### PR TITLE
Made ticket editing field update use correct ticket info.

### DIFF
--- a/app/assets/scripts/actions/index.js
+++ b/app/assets/scripts/actions/index.js
@@ -57,10 +57,17 @@ export const HIDE_AGREEMENTS = 'HIDE_AGREEMENTS';
 // Generic error checker
 
 export const checkErrors = (err) => {
-  // If the error is a 401 redirect the user to the unauthorized page.
-  if (err.response.status === 401) {
-    return {type: ADD_ERROR, error: 'unauthorized', msg: 'You are not authorized to conduct that action. If you continue to get errors try logging out and back in.'};
-  } else {
+  try {
+    // If the error is a 401 redirect the user to the unauthorized page.
+    if (err.response.status === 401) {
+      return {type: ADD_ERROR, error: 'unauthorized', msg: 'You are not authorized to conduct that action. If you continue to get errors try logging out and back in.'};
+    } else {
+      // Check non-401 API errors
+      return {type: ADD_ERROR, error: 'unknown'};
+    }
+  } catch (e) {
+    // Checks non API based errors here
+    console.log(err);
     return {type: ADD_ERROR, error: 'unknown'};
   }
 };

--- a/app/assets/scripts/utils/store.js
+++ b/app/assets/scripts/utils/store.js
@@ -1,7 +1,6 @@
 import { createStore, applyMiddleware } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import createLogger from 'redux-logger';
-
 import config from '../config';
 import reducer from '../reducers';
 

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ test:
     - yarn run test
 deployment:
   staging:
-    branch: master
+    branch: dev
     commands:
       - npm rebuild node-sass
       - DS_ENV=staging yarn run build


### PR DESCRIPTION
The component that created the ticket editing field was only being rendered once upon page load.
When its single-ticket parent updated due to state changes it did not update this form.
This was abnormal behavior compared to other components and was resistant to the normal tricks
for forcing it to re-render. As such, I added a workaround where the ticket path is used to
get the ticket information from the states tickets list. This also required fixing the groupings and delete buttons.