### PR TITLE
Made ticket-single clean up its state when done

### DIFF
--- a/app/assets/scripts/actions/index.js
+++ b/app/assets/scripts/actions/index.js
@@ -11,6 +11,7 @@ export const LOGOUT_SUCCESS = 'LOGOUT_SUCCESS';
 
 export const GET_TICKETS = 'GET_TICKETS';
 export const GET_TICKET_SINGLE = 'GET_TICKET_SINGLE';
+export const CLEAR_TICKET = 'CLEAR_TICKET';
 export const REMOVE_TICKETS = 'REMOVE_TICKETS';
 export const UPDATE_TICKET_SP = 'UPDATE_TICKET_SP';
 export const REMOVE_TICKET_SP = 'REMOVE_TICKET_SP';
@@ -159,6 +160,10 @@ export const fetchTicketSingle = ticketID => {
 
 export const removeTickets = ticketIDs => {
   return { type: REMOVE_TICKETS, ticketIDs };
+};
+
+export const clearTicket = () => {
+  return { type: CLEAR_TICKET };
 };
 
 export const deleteTickets = (ids, redirect) => {

--- a/app/assets/scripts/reducers/ticket-single.js
+++ b/app/assets/scripts/reducers/ticket-single.js
@@ -6,7 +6,8 @@ import {
   GET_TICKET_SINGLE,
   UPDATE_TICKET_SP,
   REMOVE_TICKET_SP,
-  REMOVE_TICKET_GROUPING
+  REMOVE_TICKET_GROUPING,
+  CLEAR_TICKET
 } from '../actions';
 
 export const initialState = {
@@ -32,6 +33,9 @@ export default (state = initialState, action) => {
     case REMOVE_TICKET_GROUPING:
       newState.ticket.groupings = newState.ticket.groupings
         .filter(g => g.grouping_id !== action.data.groupingID);
+      break;
+    case CLEAR_TICKET:
+      newState.ticket = {};
       break;
   }
   return newState;

--- a/app/assets/scripts/views/tickets-single.js
+++ b/app/assets/scripts/views/tickets-single.js
@@ -22,6 +22,7 @@ import {
   removeGroupingFromTicket,
   removeSPFromTicket,
   fetchTicketThreads,
+  clearTicket,
   deleteMessage,
   createMessage,
   deleteTickets,
@@ -73,13 +74,17 @@ var TicketSingle = React.createClass({
 
   componentWillMount: function () {
     const isAdmin = _.includes(this.props.roles, 'admin');
-
     this.props.dispatch(fetchTicketSingle(this.props.routeParams.ticketId));
     this.props.dispatch(fetchTicketThreads(this.props.routeParams.ticketId));
     if (isAdmin) {
       this.props.dispatch(fetchGroupings());
       this.props.dispatch(fetchImplementingPartners());
     }
+  },
+
+  componentWillUnmount: function () {
+    this.props.ticket = {};
+    this.props.dispatch(clearTicket());
   },
 
   onAddGrouping: function (groupingID) {
@@ -109,7 +114,7 @@ var TicketSingle = React.createClass({
                 this.setState({isEditTicketModalVisible: false});
               }}
               roles={roles}
-              existingTicket={ticket}
+              existingTicket={this.props.ticket}
               implementingPartners={this.props.implementingPartners}
               profile={hasProfile ? this.props.profile : {}}
             />
@@ -297,15 +302,15 @@ var TicketSingle = React.createClass({
 // Connect functions
 
 const mapStateToProps = (state, ownProps) => {
-  const { groupings, ticketSingle, serviceProviders, implementingPartners, threads } = state;
-  return Object.assign({}, ticketSingle, {
+  return {
     roles: state.auth.roles,
-    serviceProviders: serviceProviders.list,
-    groupings: groupings.groupings,
-    implementingPartners: implementingPartners.list,
-    threads: threads.threads,
-    profile: state.auth.profile
-  });
+    serviceProviders: state.serviceProviders.list,
+    groupings: state.groupings.groupings,
+    implementingPartners: state.implementingPartners.list,
+    threads: state.threads.threads,
+    profile: state.auth.profile,
+    ticket: state.ticketSingle.ticket
+  };
 };
 
 export default connect(mapStateToProps)(TicketSingle);

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ test:
     - yarn run test
 deployment:
   staging:
-    branch: master
+    branch: dev
     commands:
       - npm rebuild node-sass
       - DS_ENV=staging yarn run build


### PR DESCRIPTION
The ticket-single view was not cleaning up its state once it
exited. This commit adds that clean-up. The lack of clean up
was causing the ticket-edit component to render before the ticket
state was properly set. The edit field was not updating when the
new ticketSingle state was updated. This closes issue #66.